### PR TITLE
update packer base ami

### DIFF
--- a/Packer/ArkCase-CE/packer.json
+++ b/Packer/ArkCase-CE/packer.json
@@ -2,7 +2,7 @@
   "description": "Packer template to build an ArkCase FOIA AMI ready to be published on AWS Marketplace",
 
   "variables": {
-    "base_ami": "ami-05afa634116a37d03",
+    "base_ami": "ami-06e5b34e5ddc9fad1",
     "disk_size_gb": "100",
     "project": "arkcase-ce-core",
     "version": "{{ env `version` }}",


### PR DESCRIPTION
We tried to publish ArkCase AMI on marketplace using this base_ami_id: "ami-05afa634116a37d03" we got rejected by AWS because the scanner found ssh key in /loc.svcmgmt/.ssh/authorized_keys:1 we tried emptying this file and Amazon still rejects our request, we decide to use the same AMI as ArkCase FOIA and EE.