### PR TITLE
Update startup.sh

### DIFF
--- a/Packer/ArkCase-CE/startup.sh
+++ b/Packer/ArkCase-CE/startup.sh
@@ -4,8 +4,6 @@ set -eu -o pipefail
 
 rootdir=/opt/app/arkcase
 
-# Remove loc.svcmgmt ssh keys in order to be compliant with marketplace policies
-sudo truncate -s 0 /home/loc.svcmgmt/.ssh/authorized_keys
 # Restore ArkCase admin user if this is the first time this EC2 instances is
 # booted up
 


### PR DESCRIPTION
Remove truncate line since we decide to use the same AMI like we are using for ArkCase FOIA and EE. In that AMI this file doesn't exist. (/loc.svcmgmt/.ssh/authorized_keys)